### PR TITLE
Remove whitespace prestep

### DIFF
--- a/js/src/lexer.spec.ts
+++ b/js/src/lexer.spec.ts
@@ -43,6 +43,12 @@ describe("lexer", () => {
       assert.throws(() => lex('"sup'));
     });
 
+    it("trims whitespace", () => {
+      assert.deepStrictEqual(lex('  @  '), [
+        { token: "ref", value: "@" },
+      ]);
+    });
+
     it("parses any sequence of whitespace as a single space", () => {
       const cases = [
         '@ @',


### PR DESCRIPTION
The Whitespace prestep was affecting a lot of important features in mistql such as tracking token location and regexes. This solves that, although in a suboptimal fashion because it's inefficient. Not too big of an issue, since the set of tokens is pretty small anyways.