### PR TITLE
add indexing expressions

### DIFF
--- a/js/src/index.spec.ts
+++ b/js/src/index.spec.ts
@@ -28,35 +28,40 @@ describe("index", () => {
     });
 
     it("allows complex expressions as part of object and array literals", () => {
-      assert.deepStrictEqual(query('([-1, { isSpot: dog == "spot"}])', { dog: "spot" }),
+      assert.deepStrictEqual(
+        query('([-1, { isSpot: dog == "spot"}])', { dog: "spot" }),
         [-1, { isSpot: true }]
       );
     });
   });
 
-  describe("first", () => {
+  describe("indexing", () => {
     it("correctly grabs the first element", () => {
-      assert.strictEqual(
-        query("[1, 2, 3, 4, 5][0]", {}),
-        1
-      );
+      assert.strictEqual(query("[1, 2, 3, 4, 5][0]", {}), 1);
     });
 
     it("returns null for empty arrays", () => {
       assert.strictEqual(query("[][0]", {}), null);
-    });
-  });
-
-  describe("last", () => {
-    it("correctly grabs the last element", () => {
-      assert.strictEqual(
-        query("[1, 2, 3, 4, 5][-1]", {}),
-        5
-      );
-    });
-
-    it("returns null for empty arrays", () => {
       assert.strictEqual(query("[][-1]", {}), null);
+    });
+
+    it("correctly grabs the last element", () => {
+      assert.strictEqual(query("[1, 2, 3, 4, 5][-1]", {}), 5);
+    });
+
+    it("slices with first param missing", () => {
+      assert.deepStrictEqual(query("[1, 2, 3, 4, 5][:-1]", {}), [1, 2, 3, 4]);
+      assert.deepStrictEqual(query("[1, 2, 3, 4, 5][:3]", {}), [1, 2, 3]);
+    });
+
+    it("slices with second param missing", () => {
+      assert.deepStrictEqual(query("[1, 2, 3, 4, 5][-2:]", {}), [4, 5]);
+      assert.deepStrictEqual(query("[1, 2, 3, 4, 5][2:]", {}), [3, 4, 5]);
+    });
+
+    it("slices with first and last params", () => {
+      assert.deepStrictEqual(query("[1, 2, 3, 4, 5][1:-1]", {}), [2, 3, 4]);
+      assert.deepStrictEqual(query("[1, 2, 3, 4, 5][2:4]", {}), [3, 4]);
     });
   });
 });


### PR DESCRIPTION
This allows indexing expressions a la `"string"[0:-1] == "strin"`

This is probably last syntax addition for a while. 

solves: https://github.com/evinism/mistql/issues/21