### PR TITLE
JS <-> MistQL type correspondance

### DIFF
--- a/docs/docs/reference/implementations/_category_.json
+++ b/docs/docs/reference/implementations/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Implementations",
+  "position": 5
+}

--- a/docs/docs/reference/implementations/js.md
+++ b/docs/docs/reference/implementations/js.md
@@ -1,0 +1,51 @@
+---
+sidebar_position: 1
+---
+
+# JS Implementation
+
+The JS implementation of MistQL can be installed via `npm install mistql`.
+
+### Example Usage:
+
+```js
+import {query} from 'mistql';
+
+const len = query('count @', [1, 2, 3]);
+console.log(len);
+```
+
+### `mistql` package exports
+
+| Export | type | Description |
+|---|---|---|
+| `query` | `(query: string, data: any) => any` | The query interface for MistQL | 
+| `default` | `{query: query}` | An object solely consisting of the query interface | 
+
+### Type correspondence between JS and MistQL
+Separate from the specification of the language, the JS implementation maps from
+JS types to MistQL types in a specific manner, as documented by the table below. As
+the following is NOT part of the language, rather the library, the correspondence
+may change with further releases of the `mistql` package, following semver.
+
+If this correspondence doesn't work for you for some reason, please open an issue and
+describe the situation carefully. This correspondence is easier to change than the language
+itself.
+
+| Value | MistQL Value |
+|---|---|
+| `number` | `double` |
+| `boolean` | `boolean` |
+| `string` | `string` |
+| `object` | `object` |
+| `null` | `null` |
+| `array` | `array` |
+| `undefined` | `null` |
+| `function` | `object` with enumerated properties |
+| `Number` object | `double` |
+| `Boolean` object | `boolean` |
+| `String` object | `string` |
+| `Date` | `date.toISOString()` |
+| `Symbol` | `symbol.toString()` |
+| Anything else | `object` with enumerated properties |
+

--- a/js/src/executor.spec.ts
+++ b/js/src/executor.spec.ts
@@ -41,6 +41,22 @@ describe("executor", () => {
       );
     });
 
+    it("coerces functions to blank objects", () => {
+      assert.deepStrictEqual(inputGardenWall(() => { }), {});
+    });
+
+    it("coerces dates to timestamps", () => {
+      assert.deepStrictEqual(inputGardenWall(new Date('10-10-2020')), JSON.parse(JSON.stringify(new Date('10-10-2020'))));
+    });
+
+    it("coerces object-numbers to numbers", () => {
+      assert.deepStrictEqual(inputGardenWall(new Number(50)), 50);
+    });
+
+    it("coerces object-numbers to numbers", () => {
+      assert.deepStrictEqual(inputGardenWall(new Boolean(true)), true);
+    });
+
     it("coerces own properties", () => {
       function foo() { }
       foo.hi = "doc";

--- a/js/src/executor.ts
+++ b/js/src/executor.ts
@@ -21,7 +21,7 @@ export const inputGardenWall = (data: unknown) => {
     return data.valueOf();
   }
   if (data instanceof Date) {
-    return JSON.parse(JSON.stringify(data));
+    return data.toISOString();
   }
   if (data instanceof Symbol) {
     return data.toString();

--- a/js/src/executor.ts
+++ b/js/src/executor.ts
@@ -17,8 +17,14 @@ export const inputGardenWall = (data: unknown) => {
   if (["number", "boolean", "string"].indexOf(typeof data) > -1) {
     return data;
   }
-  if (data instanceof Number || data instanceof Boolean || data instanceof Date) {
+  if (data instanceof Number || data instanceof Boolean || data instanceof String) {
+    return data.valueOf();
+  }
+  if (data instanceof Date) {
     return JSON.parse(JSON.stringify(data));
+  }
+  if (data instanceof Symbol) {
+    return data.toString();
   }
   if (data === null || data === undefined) {
     return null;

--- a/js/src/executor.ts
+++ b/js/src/executor.ts
@@ -17,6 +17,9 @@ export const inputGardenWall = (data: unknown) => {
   if (["number", "boolean", "string"].indexOf(typeof data) > -1) {
     return data;
   }
+  if (data instanceof Number || data instanceof Boolean || data instanceof Date) {
+    return JSON.parse(JSON.stringify(data));
+  }
   if (data === null || data === undefined) {
     return null;
   }


### PR DESCRIPTION
Formalizes the correspondance between JS types and MistQL types