### PR TITLE
Make boolean operators short circuit

### DIFF
--- a/js/src/builtins/and.ts
+++ b/js/src/builtins/and.ts
@@ -1,0 +1,12 @@
+import { truthy } from "../runtimeValues";
+import { BuiltinFunction } from "../types";
+import { arity } from "../util";
+
+const and: BuiltinFunction =
+  arity(2, (args, stack, exec) => {
+    const a = exec(args[0], stack);
+    const b = exec(args[1], stack);
+    return !truthy(a) ? a : b;
+  });
+
+export default and;

--- a/js/src/builtins/index.ts
+++ b/js/src/builtins/index.ts
@@ -1,6 +1,7 @@
 import { compare, truthy } from "../runtimeValues";
 import { BuiltinFunction } from "../types";
 import { arity, validateType } from "../util";
+import and from "./and";
 import apply from "./apply";
 import count from "./count";
 import entries from "./entries";
@@ -22,6 +23,7 @@ import mapvalues from "./mapvalues";
 import match from "./match";
 import not from "./not";
 import notequal from "./notequal";
+import or from "./or";
 import plus from "./plus";
 import reduce from "./reduce";
 import regex from "./regex";
@@ -43,15 +45,6 @@ const numericBinaryOperator = (
   arity(2, (args, stack, exec) => {
     const a = validateType("number", exec(args[0], stack));
     const b = validateType("number", exec(args[1], stack));
-    return op(a, b);
-  });
-
-const booleanBinaryOperator = (
-  op: (a: boolean, b: boolean) => boolean
-): BuiltinFunction =>
-  arity(2, (args, stack, exec) => {
-    const a = validateType("boolean", exec(args[0], stack));
-    const b = validateType("boolean", exec(args[1], stack));
     return op(a, b);
   });
 
@@ -145,8 +138,8 @@ export default {
   "*": numericBinaryOperator((a, b) => a * b),
   "/": numericBinaryOperator((a, b) => a / b),
   "%": numericBinaryOperator((a, b) => a % b),
-  "||": booleanBinaryOperator((a, b) => a || b),
-  "&&": booleanBinaryOperator((a, b) => a && b),
+  "||": or,
+  "&&": and,
   "==": equal,
   "!=": notequal,
   ">": binaryCompareFunction([true, false, false]),

--- a/js/src/builtins/or.ts
+++ b/js/src/builtins/or.ts
@@ -1,0 +1,12 @@
+import { truthy } from "../runtimeValues";
+import { BuiltinFunction } from "../types";
+import { arity } from "../util";
+
+const or: BuiltinFunction =
+  arity(2, (args, stack, exec) => {
+    const a = exec(args[0], stack);
+    const b = exec(args[1], stack);
+    return truthy(a) ? a : b;
+  });
+
+export default or;

--- a/shared/testdata.json
+++ b/shared/testdata.json
@@ -450,6 +450,131 @@
           ]
         },
         {
+          "describe": "#[boolean binary operators]",
+          "cases": [
+            {
+              "it": "can and booleans",
+              "assertions": [
+                {
+                  "query": "true && true",
+                  "data": {},
+                  "expected": true
+                },
+                {
+                  "query": "true && false",
+                  "data": {},
+                  "expected": false
+                },
+                {
+                  "query": "false && true",
+                  "data": {},
+                  "expected": false
+                },
+                {
+                  "query": "false && false",
+                  "data": {},
+                  "expected": false
+                }
+              ]
+            },
+            {
+              "it": "can or booleans",
+              "assertions": [
+                {
+                  "query": "true || true",
+                  "data": {},
+                  "expected": true
+                },
+                {
+                  "query": "true || false",
+                  "data": {},
+                  "expected": true
+                },
+                {
+                  "query": "false || true",
+                  "data": {},
+                  "expected": true
+                },
+                {
+                  "query": "false || false",
+                  "data": {},
+                  "expected": false
+                }
+              ]
+            },
+            {
+              "it": "allows short circuting with and",
+              "assertions": [
+                {
+                  "query": "null && 0",
+                  "data": {},
+                  "expected": null
+                },
+                {
+                  "query": "null && 1",
+                  "data": {},
+                  "expected": null
+                },
+                {
+                  "query": "0 && null",
+                  "data": {},
+                  "expected": 0
+                },
+                {
+                  "query": "1 && null",
+                  "data": {},
+                  "expected": null
+                },
+                {
+                  "query": "1 && 0",
+                  "data": {},
+                  "expected": 0
+                },
+                {
+                  "query": "1 && 2",
+                  "data": {},
+                  "expected": 2
+                }
+              ]
+            },
+            {
+              "it": "allows short circuting with or",
+              "assertions": [
+                {
+                  "query": "null || 0",
+                  "data": {},
+                  "expected": 0
+                },
+                {
+                  "query": "null || 1",
+                  "data": {},
+                  "expected": 1
+                },
+                {
+                  "query": "0 || null",
+                  "data": {},
+                  "expected": null
+                },
+                {
+                  "query": "1 || null",
+                  "data": {},
+                  "expected": 1
+                },
+                {
+                  "query": "1 || 0",
+                  "data": {},
+                  "expected": 1
+                },
+                {
+                  "query": "1 || 2",
+                  "data": {},
+                  "expected": 1
+                }
+              ]
+            }
+          ]
+        },
+        {
           "describe": "#[comparators]",
           "cases": [
             {


### PR DESCRIPTION
Can be released before 0.5.0. Backwards compatible as before it would error for non-booleans. Narrow behavior to start FTW!

closes #54 