### PR TITLE
add in stringjoin alias in prep for deprecation of join

### DIFF
--- a/js/src/builtins/index.ts
+++ b/js/src/builtins/index.ts
@@ -113,6 +113,7 @@ export default {
   if: ifFunction,
   index: indexFn,
   join,
+  stringjoin: join,
   keys,
   log,
   match,

--- a/shared/testdata.json
+++ b/shared/testdata.json
@@ -1901,13 +1901,13 @@
           ]
         },
         {
-          "describe": "#join",
+          "describe": "#stringjoin",
           "cases": [
             {
               "it": "joins basic strings",
               "assertions": [
                 {
-                  "query": "join \"\" @",
+                  "query": "stringjoin \"\" @",
                   "data": [
                     "a",
                     "b",
@@ -1921,7 +1921,7 @@
               "it": "joins with a delimiter",
               "assertions": [
                 {
-                  "query": "join \" \" @",
+                  "query": "stringjoin \" \" @",
                   "data": [
                     "a",
                     "b",
@@ -1935,7 +1935,7 @@
               "it": "round-trips with split",
               "assertions": [
                 {
-                  "query": "(split \":\" @ | join \":\") == @",
+                  "query": "(split \":\" @ | stringjoin \":\") == @",
                   "data": "hello:hi:cattt:",
                   "expected": true
                 }


### PR DESCRIPTION
Relates to #61. Just going to have an alias for 0.4.x, but for 0.5.0 i'm going to remove it. 