### PR TITLE
Make pipes pass values through infinitely

### DIFF
--- a/js/src/executor.ts
+++ b/js/src/executor.ts
@@ -75,6 +75,7 @@ const executeInner: ExecutionFunction = (
       return executeApplication(statement, stack);
     case "pipeline":
       let last: RuntimeValue = executeInner(statement.stages[0], stack);
+      let newStack = stack;
       for (let i = 1; i < statement.stages.length; i++) {
         const stage = statement.stages[i];
         let app: ASTApplicationExpression;
@@ -92,7 +93,8 @@ const executeInner: ExecutionFunction = (
             arguments: [atRef],
           };
         }
-        last = executeApplication(app, pushRuntimeValueToStack(last, stack));
+        newStack = pushRuntimeValueToStack(last, newStack)
+        last = executeApplication(app, pushRuntimeValueToStack(last, newStack));
       }
       return last;
   }

--- a/py/mistql/execute.py
+++ b/py/mistql/execute.py
@@ -33,9 +33,10 @@ def execute_pipe(stages: List[Expression], stack: Stack) -> RuntimeValue:
     first: Expression = stages[0]
     remaining: List[Expression] = stages[1:]
     data = execute(first, stack)
+    new_stack = stack
 
     for stage_ast in remaining:
-        new_stack = add_runtime_value_to_stack(data, stack)
+        new_stack = add_runtime_value_to_stack(data, new_stack)
         fn: Expression
         args: List[Expression]
         if isinstance(stage_ast, FnExpression):

--- a/shared/testdata.json
+++ b/shared/testdata.json
@@ -499,6 +499,16 @@
                   "expected": "barbar"
                 }
               ]
+            },
+            {
+              "it": "lets the first stage propagate keys to the next pipe segment",
+              "assertions": [
+                {
+                  "query": "{key: 1} | if key == 1 2 | if key == 1 3",
+                  "data": null,
+                  "expected": 3
+                }
+              ]
             }
           ]
         },


### PR DESCRIPTION
This is a fairly major change, semantically speaking. That being said, it makes a lot of sense to do -- having it propagate exactly once is pretty strange.