### PR TITLE
allow piped expressions without parens in object and array literals

### DIFF
--- a/py/mistql/parse.py
+++ b/py/mistql/parse.py
@@ -45,9 +45,9 @@ _wslr{param}: _W? param _W?
     | FALSE
     | NULL
 
-array  : _wsr{"["} (simple_expression (_wslr{","} simple_expression)*)? _wsl{"]"} -> array
+array  : _wsr{"["} (piped_expression (_wslr{","} piped_expression)*)? _wsl{"]"} -> array
 object : _wsr{"{"} (object_entry (_wslr{","} object_entry)*)? _wsl{"}"} -> object
-object_entry : (ESCAPED_STRING | CNAME) _wslr{":"} simple_expression -> object_entry
+object_entry : (ESCAPED_STRING | CNAME) _wslr{":"} piped_expression -> object_entry
 
 WCOLON: WS? ":" WS?
 

--- a/shared/testdata.json
+++ b/shared/testdata.json
@@ -968,6 +968,60 @@
                     "spotCount": 2,
                     "dog": "spot"
                   }
+                },
+                {
+                  "query": "[-1 - 500, { isSpot: dog == \"spot\"}, events | filter type==\"purchase\" | count]",
+                  "data": {
+                    "dog": "spot",
+                    "events": [
+                      {
+                        "type": "purchase"
+                      },
+                      {
+                        "type": "purchase"
+                      },
+                      {
+                        "type": "click"
+                      }
+                    ]
+                  },
+                  "expected": [
+                    -501,
+                    {
+                      "isSpot": true
+                    },
+                    2
+                  ]
+                },
+                {
+                  "query": "{ spotCount: events | filter type =~ \"p[ae]t\" | count, dog: \"spot\" }",
+                  "data": {
+                    "events": [
+                      {
+                        "type": "pet"
+                      },
+                      {
+                        "type": "pat"
+                      },
+                      {
+                        "type": "pot"
+                      }
+                    ]
+                  },
+                  "expected": {
+                    "spotCount": 2,
+                    "dog": "spot"
+                  }
+                },
+                {
+                  "query": "{ ct: [5] | count } | entries",
+                  "data": null,
+                  "expected": [
+                    [
+                      "ct",
+                      1
+                    ]
+                  ]
                 }
               ]
             }


### PR DESCRIPTION
The fact that I didn't catch this before is a testament to how tough it is to make a comprehensive test suite and formal grammar.