### PR TITLE
Eliminate NaN and infinity entirely from mistql.

### DIFF
--- a/js/src/builtins/index.ts
+++ b/js/src/builtins/index.ts
@@ -1,3 +1,4 @@
+import { RuntimeError } from "../errors";
 import { compare, truthy } from "../runtimeValues";
 import { BuiltinFunction } from "../types";
 import { arity, validateType } from "../util";
@@ -87,6 +88,13 @@ const matchBinaryOp: BuiltinFunction = arity(2, (args, stack, exec) =>
   match(args.slice().reverse(), stack, exec)
 );
 
+const divide = numericBinaryOperator((a, b) => {
+  if (b === 0) {
+    throw new RuntimeError("Division by zero");
+  }
+  return (a / b);
+});
+
 export default {
   apply,
   count,
@@ -128,7 +136,7 @@ export default {
   "+": plus,
   "-": numericBinaryOperator((a, b) => a - b),
   "*": numericBinaryOperator((a, b) => a * b),
-  "/": numericBinaryOperator((a, b) => a / b),
+  "/": divide,
   "%": numericBinaryOperator((a, b) => a % b),
   "||": or,
   "&&": and,

--- a/js/src/executor.spec.ts
+++ b/js/src/executor.spec.ts
@@ -57,6 +57,24 @@ describe("executor", () => {
       assert.deepStrictEqual(inputGardenWall(new Boolean(true)), true);
     });
 
+    it("coerces NaN to null internally", () => {
+      assert.deepStrictEqual(inputGardenWall(NaN), null);
+    });
+
+    it("coerces infinity to null internally", () => {
+      assert.deepStrictEqual(inputGardenWall(Infinity), null);
+      assert.deepStrictEqual(inputGardenWall(-Infinity), null);
+    });
+
+    it("coerces object-number NaN to null internally", () => {
+      assert.deepStrictEqual(inputGardenWall(new Number(NaN)), null);
+    });
+
+    it("coerces object-number infinity to null internally", () => {
+      assert.deepStrictEqual(inputGardenWall(new Number(Infinity)), null);
+      assert.deepStrictEqual(inputGardenWall(new Number(-Infinity)), null);
+    });
+
     it("coerces own properties", () => {
       function foo() { }
       foo.hi = "doc";

--- a/js/src/executor.ts
+++ b/js/src/executor.ts
@@ -14,10 +14,17 @@ import {
 
 
 export const inputGardenWall = (data: unknown) => {
-  if (["number", "boolean", "string"].indexOf(typeof data) > -1) {
+  if (typeof data === "number" || data instanceof Number) {
+    let number = data instanceof Number ? data.valueOf() : data;
+    if (Number.isNaN(number) || !Number.isFinite(number)) {
+      return null;
+    }
+    return number;
+  }
+  if (["boolean", "string"].indexOf(typeof data) > -1) {
     return data;
   }
-  if (data instanceof Number || data instanceof Boolean || data instanceof String) {
+  if (data instanceof Boolean || data instanceof String) {
     return data.valueOf();
   }
   if (data instanceof Date) {

--- a/py/mistql/runtime_value.py
+++ b/py/mistql/runtime_value.py
@@ -1,3 +1,4 @@
+from math import isfinite, isnan
 from enum import Enum
 from typing import Any, Callable, Dict, Union, Set
 import json
@@ -62,6 +63,8 @@ class RuntimeValue:
         elif isinstance(value, int):
             return RuntimeValue(RuntimeValueType.Number, float(value))
         elif isinstance(value, float):
+            if isnan(value) or not isfinite(value):
+                return RuntimeValue(RuntimeValueType.Null)
             return RuntimeValue(RuntimeValueType.Number, value)
         elif isinstance(value, str):
             return RuntimeValue(RuntimeValueType.String, value)

--- a/py/tests/test_gardenwall.py
+++ b/py/tests/test_gardenwall.py
@@ -1,0 +1,15 @@
+from math import nan, inf
+from mistql.gardenwall import input_garden_wall
+from mistql.runtime_value import RuntimeValue
+
+
+def test_nan_converts_to_null_value():
+    assert input_garden_wall(nan) == RuntimeValue.of(None)
+
+
+def test_inf_converts_to_null_value():
+    assert input_garden_wall(inf) == RuntimeValue.of(None)
+
+
+def test_neg_inf_converts_to_null_value():
+    assert input_garden_wall(-inf) == RuntimeValue.of(None)

--- a/shared/testdata.json
+++ b/shared/testdata.json
@@ -1538,6 +1538,16 @@
               ]
             },
             {
+              "it": "Throws on divide by zero",
+              "assertions": [
+                {
+                  "query": "1 / 0",
+                  "data": {},
+                  "throws": true
+                }
+              ]
+            },
+            {
               "it": "can modulo numbers",
               "assertions": [
                 {


### PR DESCRIPTION
Eliminates NaN and infinity in MistQL. Done via asserting that `1 / 0` errors, since float already errors on a non-number. Additionally asserts that garden walls in py and js explicitly map it to null. 

Fixes https://github.com/evinism/mistql/issues/118