### PR TITLE
formalize stack behavior of context propagation

### DIFF
--- a/shared/testdata.json
+++ b/shared/testdata.json
@@ -11,16 +11,8 @@
               "assertions": [
                 {
                   "query": "@",
-                  "data": [
-                    1,
-                    2,
-                    3
-                  ],
-                  "expected": [
-                    1,
-                    2,
-                    3
-                  ]
+                  "data": [1, 2, 3],
+                  "expected": [1, 2, 3]
                 }
               ]
             },
@@ -168,12 +160,12 @@
                 {
                   "query": "4.9E-50",
                   "data": null,
-                  "expected": 4.9E-50
+                  "expected": 4.9e-50
                 },
                 {
                   "query": "4.9E50",
                   "data": null,
-                  "expected": 4.9E50
+                  "expected": 4.9e50
                 },
                 {
                   "query": "0.9",
@@ -263,37 +255,12 @@
                 {
                   "query": "[1, 2, 3]",
                   "data": null,
-                  "expected": [
-                    1,
-                    2,
-                    3
-                  ]
+                  "expected": [1, 2, 3]
                 },
                 {
                   "query": "[[],[],[[[[],[],[[[]],[\"dog\"]]]]],[],\"cat\"]",
                   "data": null,
-                  "expected": [
-                    [],
-                    [],
-                    [
-                      [
-                        [
-                          [],
-                          [],
-                          [
-                            [
-                              []
-                            ],
-                            [
-                              "dog"
-                            ]
-                          ]
-                        ]
-                      ]
-                    ],
-                    [],
-                    "cat"
-                  ]
+                  "expected": [[], [], [[[[], [], [[[]], ["dog"]]]]], [], "cat"]
                 }
               ]
             },
@@ -483,16 +450,9 @@
                   "query": "$.filter @ > 1 nums",
                   "data": {
                     "filter": "cat",
-                    "nums": [
-                      1,
-                      2,
-                      3
-                    ]
+                    "nums": [1, 2, 3]
                   },
-                  "expected": [
-                    2,
-                    3
-                  ]
+                  "expected": [2, 3]
                 }
               ]
             },
@@ -541,18 +501,14 @@
                   "data": {
                     "toggle": true
                   },
-                  "expected": [
-                    "one"
-                  ]
+                  "expected": ["one"]
                 },
                 {
                   "query": "(if toggle keys values) {one: \"two\"}",
                   "data": {
                     "toggle": false
                   },
-                  "expected": [
-                    "two"
-                  ]
+                  "expected": ["two"]
                 }
               ]
             }
@@ -590,6 +546,27 @@
                   "query": "{key: 1} | if key == 1 2 | if key == 1 3",
                   "data": null,
                   "throws": true
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "describe": "context propagation",
+          "cases": [
+            {
+              "it": "treats context variables like a stack rather than an overwrite",
+              "assertions": [
+                {
+                  "query": "foo | apply [bar, @.zap, bleep] | stringjoin \" \"",
+                  "data": {
+                    "foo": {
+                      "bar": "baz",
+                      "zap": "zoop"
+                    },
+                    "bleep": "bloop"
+                  },
+                  "expected": "baz zoop bloop"
                 }
               ]
             }
@@ -966,13 +943,7 @@
                 {
                   "query": "\t[ ([(    [@] )]\n)]",
                   "data": "hi",
-                  "expected": [
-                    [
-                      [
-                        "hi"
-                      ]
-                    ]
-                  ]
+                  "expected": [[["hi"]]]
                 },
                 {
                   "query": "count\t[4]",
@@ -1095,12 +1066,7 @@
                 {
                   "query": "{ ct: [5] | count } | entries",
                   "data": null,
-                  "expected": [
-                    [
-                      "ct",
-                      1
-                    ]
-                  ]
+                  "expected": [["ct", 1]]
                 }
               ]
             }


### PR DESCRIPTION
JS and Python both treat context like a stack, e.g. if context for expression 1 is within context for expression 2, then the variables from both those contexts are available. You can see an example within the test case.

We rely on this behavior in production currently, as illustrated below. The fact that we use this currently in production is strong evidence that it's both intuitive and useful behavior.

Query for # events in current session: 

`events | filter sessionId == currentSessionId | count`

Data: 
```json
{
  "currentSessionId": "sess2",
  "events": [
    {"sessionId": "sess2" },
    {"sessionId": "sess2" },
    {"sessionId": "sess1" }
    {"sessionId": "sess1" }
  ]
}
```

This PR puts this behavior into its own standalone test case. 