### PR TITLE
add test case for weird $ behavior, make pass in python and JS

### DIFF
--- a/js/src/types.ts
+++ b/js/src/types.ts
@@ -46,13 +46,23 @@ export type ASTApplicationExpression = {
   type: "application";
   function: ASTExpression;
   arguments: ASTExpression[];
+
+  // The below is a nasty hack, but it's useful for distinguishing for
+  // whether we need to wrap the function in piped expressions
+  _shouldntWrapInPipedExpressions?: boolean;
+};
+
+export type ASTParentheticalExpression = {
+  type: "parenthetical";
+  expression: ASTExpression;
 };
 
 export type ASTExpression =
   | ASTApplicationExpression
   | ASTReferenceExpression
   | ASTPipelineExpression
-  | ASTLiteralExpression;
+  | ASTLiteralExpression
+  | ASTParentheticalExpression;
 
 /* Runtime types */
 export type RuntimeValue =

--- a/py/mistql/execute.py
+++ b/py/mistql/execute.py
@@ -36,6 +36,8 @@ def execute_pipe(stages: List[BaseExpression], stack: Stack) -> RuntimeValue:
 
     for stage_ast in remaining:
         new_stack = add_runtime_value_to_stack(data, stack)
+        if not isinstance(stage_ast, FnExpression):
+            raise OpenAnIssueIfYouGetThisError("Pipe stage is not a function!!")
         args: List[BaseExpression] = stage_ast.args.copy()
         args.append(ValueExpression(data))
         stage = FnExpression(stage_ast.fn, args)

--- a/py/mistql/execute.py
+++ b/py/mistql/execute.py
@@ -36,16 +36,9 @@ def execute_pipe(stages: List[BaseExpression], stack: Stack) -> RuntimeValue:
 
     for stage_ast in remaining:
         new_stack = add_runtime_value_to_stack(data, stack)
-        fn: BaseExpression
-        args: List[BaseExpression]
-        if isinstance(stage_ast, FnExpression):
-            fn = stage_ast.fn
-            args = stage_ast.args.copy()
-        else:
-            fn = stage_ast
-            args = []
+        args: List[BaseExpression] = stage_ast.args.copy()
         args.append(ValueExpression(data))
-        stage = FnExpression(fn, args)
+        stage = FnExpression(stage_ast.fn, args)
         data = execute(stage, new_stack)
 
     return data

--- a/py/mistql/grammar.lark
+++ b/py/mistql/grammar.lark
@@ -12,10 +12,10 @@ _wslr{param}: _W? param _W?
 ?start: piped_expression
 
 ?piped_expression: simple_expression
-    | simple_expression ("|" simple_expression)+ -> pipe
+    | simple_expression ("|" _wslr{fncall})+ -> pipe
 ?simple_expression : _wslr{op_a} | _wslr{fncall}
 ?simplevalue: literal | reference | _wsr{"("} piped_expression _wsl{")"}
-?fncall: op_a (_W op_a)+ -> fncall
+?fncall: op_a (_W op_a)* -> fncall
 
 ?reference: CNAME | AT | DOLLAR
 ?literal: object

--- a/shared/testdata.json
+++ b/shared/testdata.json
@@ -558,6 +558,21 @@
                   "throws": true
                 }
               ]
+            },
+            {
+              "it": "treats the whole of the rhs of a pipe as a function if passed with parens",
+              "assertions": [
+                {
+                  "query": "[0, 0] | (if true count null)",
+                  "data": null,
+                  "expected": 2
+                },
+                {
+                  "query": "[0, 0] | if true count null",
+                  "data": null,
+                  "throws": true
+                }
+              ]
             }
           ]
         },

--- a/shared/testdata.json
+++ b/shared/testdata.json
@@ -1096,6 +1096,73 @@
               ]
             }
           ]
+        },
+        {
+          "describe": "associativity in weird cases",
+          "cases": [
+            {
+              "it": "handles a shotgun of different associativities",
+              "assertions": [
+                {
+                  "query": "(1 - 2 + 3 - 4 + 5) == ((((1 - 2) + 3) - 4) + 5)",
+                  "data": null,
+                  "expected": true
+                },
+                {
+                  "query": "(1 / 2 * 3 / 4 * 5) == ((((1 / 2) * 3) / 4) * 5)",
+                  "data": null,
+                  "expected": true
+                },
+                {
+                  "query": "(!-1) == (!(-1))",
+                  "data": null,
+                  "expected": true
+                },
+                {
+                  "query": "(one - two - three) == ((one - two) - three)",
+                  "data": {
+                    "one": 1,
+                    "two": 2.5,
+                    "three": 3.9393
+                  },
+                  "expected": true
+                },
+                {
+                  "query": "(one - two * three) == (one - (two * three))",
+                  "data": {
+                    "one": 1,
+                    "two": 2.5,
+                    "three": 3.9393
+                  },
+                  "expected": true
+                },
+                {
+                  "query": "(a == b * 5) == (a == (b * 5))",
+                  "data": {
+                    "a": 100.59,
+                    "b": 30
+                  },
+                  "expected": true
+                },
+                {
+                  "query": "(a / 3 + 2 == b * 5) == (((a / 3) + 2) == (b * 5))",
+                  "data": {
+                    "a": 10.59,
+                    "b": 3.5
+                  },
+                  "expected": true
+                },
+                {
+                  "query": "(a / 3 + 2 == b * 5 | apply @) == ((((a / 3) + 2) == (b * 5)) | apply @)",
+                  "data": {
+                    "a": 10.59,
+                    "b": 3.5
+                  },
+                  "expected": true
+                }
+              ]
+            }
+          ]
         }
       ]
     },

--- a/shared/testdata.json
+++ b/shared/testdata.json
@@ -471,6 +471,16 @@
               ]
             },
             {
+              "it": "allows single-argument functions in piped expressions via the $ key",
+              "assertions": [
+                {
+                  "query": "[null, null, null, null, null, null] | $.count",
+                  "data": null,
+                  "expected": 6
+                }
+              ]
+            },
+            {
               "it": "gives us a method for un-overwriting things in the data param",
               "assertions": [
                 {


### PR DESCRIPTION
This behavior was dysfunctional: `[null, null, null, null, null, null] | $.count`