### PR TITLE
Allow numbers with trailing dots in js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Format [Keep A ChangeLog](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 - https://github.com/evinism/mistql/pull/150 Modified JS implementation `#index` and `#split` functions to match the expected unicode behavior as established above.
 
+### Fixed
+- https://github.com/evinism/mistql/pull/152 Allowed numbers to end in bare decimal points
+
 ## [0.4.9] 2022-05-05
 
 ### Added

--- a/js/src/lexer.ts
+++ b/js/src/lexer.ts
@@ -27,7 +27,7 @@ const vaccumsWhitespace = (token: string, direction: "l" | "r") => {
 const refStarter = /[a-zA-Z_]/;
 const refContinuer = /[a-zA-Z_0-9]/;
 const numStarter = /[0-9]/;
-const numIsValid = /^(0|([1-9][0-9]*))(\.[0-9]+)?([eE][+-]?[0-9]+)?/;
+const numIsValid = /^(0|([1-9][0-9]*))(\.[0-9]*)?([eE][+-]?[0-9]+)?/;
 const whitespace = /\s/;
 
 export function lex(raw: string): LexToken[] {

--- a/shared/testdata.json
+++ b/shared/testdata.json
@@ -186,7 +186,6 @@
             },
             {
               "it": "parses numbers which end with a decimal point",
-              "skip": ["js"],
               "assertions": [
                 {
                   "query": "0.",
@@ -202,6 +201,11 @@
                   "query": "(5.)",
                   "data": null,
                   "expected": 5
+                },
+                {
+                  "query": "-9.e2",
+                  "data": null,
+                  "expected": -900
                 }
               ]
             },


### PR DESCRIPTION
JS mistql implementation failed on the expression `1.`. This fixes that issue. 