### PR TITLE
Add interface for supplying custom functions to MistQL

### DIFF
--- a/docs/docs/reference/implementations/_category_.json
+++ b/docs/docs/reference/implementations/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Implementations",
-  "position": 6
+  "position": 7
 }

--- a/docs/docs/reference/implementations/js.md
+++ b/docs/docs/reference/implementations/js.md
@@ -9,7 +9,7 @@ The JS implementation of MistQL can be installed via `npm install mistql`.
 ### Example Usage:
 
 ```js
-import {query} from 'mistql';
+import { query } from 'mistql';
 
 const len = query('count @', [1, 2, 3]);
 console.log(len);
@@ -19,8 +19,13 @@ console.log(len);
 
 | Export | type | Description |
 |---|---|---|
-| `query` | `(query: string, data: any) => any` | The query interface for MistQL | 
-| `default` | `{query: query}` | An object solely consisting of the query interface | 
+| `query` | `(query: string, data: any) => any` | The default query function for MistQL. Most uses of MistQL can rely solely on this function |
+| `defaultInstance` | `MistQLInstance` | The default instance of MistQL. The exported `query` function is an alias to the `query` method on the default instance |
+| `MistQLInstance` | `class` | The class for constructing parameterized MistQL instances. If you're adding custom functions to MistQL, you'll use this interface. |
+| `jsFunctionToMistQLFunction` | `(fn) => FunctionValue` | Helper function for constructing MistQL functions from JS functions |
+| `default` | `{query, defaultInstance, }` | An object consisting of the  | 
+
+MistQL also exposes a number of TS types through the default interface, although they're not listed here.
 
 ### Type correspondence between JS and MistQL
 Separate from the specification of the language, the JS implementation maps from

--- a/docs/docs/reference/writing_custom_functions.md
+++ b/docs/docs/reference/writing_custom_functions.md
@@ -1,0 +1,58 @@
+---
+sidebar_position: 6
+---
+
+# Writing Custom Functions
+
+WARNING: Custom functions are currently only available in the JS implementation of MistQL, and are relatively unstable. Use with caution, and/or ping the Discord if you need help.
+
+There might be instances where MistQL's builtin functions don't provide enough flexibility, but you still want to maintain the MistQL query language interface. The JS implementation provides a mechanism for adding custom functions to MistQL.
+
+## Basic Example
+
+Below is a basic example of writing a custom function available inside a MistQL query:
+
+```js
+import {
+  MistQLInstance, 
+  jsFunctionToMistQLFunction as jsToMQ
+} from 'mistql';
+
+const mq = new MistQLInstance({
+  extras: {
+    sumthree: jsToMQ((a, b, c) => a + b + c);
+  }
+});
+
+console.log(mq.query("sumthree 1 2 3", null)); // Prints 6
+```
+
+The above eagerly evaluates the 3 arguments to the `threesum` function and passes them to the JS function. The `extras` key in the options parameter to `MistQLInstance` contains a mapping from lexical name to a MistQL `FunctionValue`.
+
+## A level deeper
+
+Since MistQL lazily evaluates subexpressions due to [contextualized expressions](../tutorial/contextualized-expressions.md), the `extras` dictionary expects `FunctionValue`s as keys rather than converting arbitrary JS functions to MistQL functions.
+
+The type of `FunctionValue` in MistQL is as follows:
+
+```ts
+type FunctionValue = (
+  args: ASTExpression[],
+  stack: Closure[], 
+  exec: (args: ASTExpression, stack: Closure[]) => RuntimeValue
+) => RuntimeValue
+```
+
+The arguments to this function are as follows
+
+| Argument | Meaning |
+|---|---|
+| `args` | The arguments passed to the function in MistQL. Since these arguments haven't yet been evaluated, they are passed in AST format |
+| `stack` | The current lexical scope of the function. This should not be modified. |
+| `exec` | A callback method to execute subexpressions under  |
+
+This is the same interface that the MistQL JS implementation uses internally for builtin functions, and as such, you can look at the [builtin implementations](https://github.com/evinism/mistql/tree/main/js/src/builtins) for clean examples on how to write custom functions.
+
+### `jsFunctionToMistQLFunction`
+
+For many cases, we can use the `jsFunctionToMistQLFunction` helper, as it does mostly what one might expect. It validates arity, eagerly evaluates the arguments under the current lexical scope, and evaluates the JS function with the runtime values passed in as arguments.

--- a/js/src/executor.ts
+++ b/js/src/executor.ts
@@ -9,9 +9,9 @@ import {
   ASTReferenceExpression,
   Closure,
   ExecutionFunction,
-  RuntimeValue
+  FunctionClosure,
+  RuntimeValue,
 } from "./types";
-
 
 export const inputGardenWall = (data: unknown) => {
   if (typeof data === "number" || data instanceof Number) {
@@ -49,7 +49,7 @@ export const inputGardenWall = (data: unknown) => {
 };
 
 export const outputGardenWall = (data: unknown) => {
-  const outputType = getType(data)
+  const outputType = getType(data);
   if (outputType === "function" || outputType === "regex") {
     throw new RuntimeError(
       `Return value of query is "${outputType}", aborting!`
@@ -69,11 +69,19 @@ export const outputGardenWall = (data: unknown) => {
   }
 };
 
-export const execute = (node: ASTExpression, variables: unknown) => {
+export const execute = (
+  node: ASTExpression,
+  variables: unknown,
+  extras?: FunctionClosure
+) => {
   const data = inputGardenWall(variables);
-  const initialStack = [builtins, {
-    $: Object.assign({}, builtins, { "@": data }),
-  }];
+  const functions = extras ? Object.assign({}, builtins, extras) : builtins;
+  const initialStack = [
+    functions,
+    {
+      $: Object.assign({}, functions, { "@": data }),
+    },
+  ];
 
   const result = executeInner(
     node,

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -1,8 +1,20 @@
-import { execute } from "./executor";
-import { parseOrThrow } from "./parser";
+import {
+  defaultInstance as DI,
+  MistQLInstance as MQI,
+  MistQLOptions as MQO,
+} from "./instance";
+export {
+  FunctionValue,
+  RuntimeValue,
+  RuntimeValueType,
+  FunctionClosure,
+  ASTExpression,
+} from "./types";
 
-export const query = (query: string, data: any) => {
-  return execute(parseOrThrow(query), data);
-};
+export const MistQLInstance = MQI;
+export const defaultInstance = DI;
+export const query = DI.query;
 
-export default { query };
+export type MistQLOptions = MQO;
+
+export default { query, defaultInstance, MistQLInstance };

--- a/js/src/instance.spec.ts
+++ b/js/src/instance.spec.ts
@@ -1,0 +1,55 @@
+import { MistQLInstance } from "./instance";
+import assert from "assert";
+import { jsFunctionToMistQLFunction } from "./util";
+
+describe("Instance", () => {
+  describe("#query", () => {
+    it("should return the value of a simple query", () => {
+      const instance = new MistQLInstance();
+      assert.strictEqual(instance.query("hello", { hello: "there" }), "there");
+    });
+  });
+
+  describe("extras", () => {
+    it("should allow for basic extra functions", () => {
+      const instance = new MistQLInstance({
+        extras: {
+          basicFunction: () => 1 + 2,
+        },
+      });
+      assert.strictEqual(instance.query("@ | basicFunction", null), 3);
+    });
+
+    it("should allow complicated extra functions", () => {
+      const sumargs = (args, stack, exec) =>
+        args.map((arg) => exec(arg, stack)).reduce((a, b) => a + b, 0);
+      const instance = new MistQLInstance({
+        extras: {
+          sumargs,
+        },
+      });
+      assert.strictEqual(
+        instance.query("sumargs 0 1 2 3 4 5 100 (-9)", null),
+        106
+      );
+    });
+
+    it("should accept usage of the jsFunctionToMistQLFunction method", () => {
+      const instance = new MistQLInstance({
+        extras: {
+          intersperse: jsFunctionToMistQLFunction((a, b) =>
+            a.flatMap((x) => [x, b]).slice(0, -1)
+          ),
+        },
+      });
+      assert.deepStrictEqual(
+        instance.query("intersperse [1, 2, 3] @", "and a"),
+        [1, "and a", 2, "and a", 3]
+      );
+
+      assert.throws(() => {
+        instance.query("intersperse 1 2 3", null);
+      });
+    });
+  });
+});

--- a/js/src/instance.spec.ts
+++ b/js/src/instance.spec.ts
@@ -14,7 +14,7 @@ describe("Instance", () => {
     it("should allow for basic extra functions", () => {
       const instance = new MistQLInstance({
         extras: {
-          basicFunction: () => 1 + 2,
+          basicFunction: (_) => 1 + 2,
         },
       });
       assert.strictEqual(instance.query("@ | basicFunction", null), 3);
@@ -25,7 +25,7 @@ describe("Instance", () => {
         args.map((arg) => exec(arg, stack)).reduce((a, b) => a + b, 0);
       const instance = new MistQLInstance({
         extras: {
-          sumargs,
+          sumargs: { definition: sumargs },
         },
       });
       assert.strictEqual(
@@ -34,12 +34,10 @@ describe("Instance", () => {
       );
     });
 
-    it("should accept usage of the jsFunctionToMistQLFunction method", () => {
+    it("should accept simple bare function uses", () => {
       const instance = new MistQLInstance({
         extras: {
-          intersperse: jsFunctionToMistQLFunction((a, b) =>
-            a.flatMap((x) => [x, b]).slice(0, -1)
-          ),
+          intersperse: (a, b) => a.flatMap((x) => [x, b]).slice(0, -1),
         },
       });
       assert.deepStrictEqual(

--- a/js/src/instance.ts
+++ b/js/src/instance.ts
@@ -1,20 +1,41 @@
 import { execute } from "./executor";
 import { parseOrThrow } from "./parser";
-import { FunctionClosure } from "./types";
+import { FunctionClosure, FunctionValue } from "./types";
+import { jsFunctionToMistQLFunction } from "./util";
+
+type Extras = {
+  [key: string]:
+    | ((...args: any[]) => any)
+    | {
+        definition: FunctionValue;
+      };
+};
 
 export type MistQLOptions = {
-  extras?: FunctionClosure;
+  extras?: Extras;
 };
 
 export class MistQLInstance {
-  extras?: FunctionClosure;
+  _extras: FunctionClosure;
 
   constructor(options: MistQLOptions = {}) {
-    this.extras = options.extras;
+    if (options.extras) {
+      this._extras = {};
+      for (let i in options.extras) {
+        if (options.extras.hasOwnProperty(i)) {
+          const value = options.extras[i];
+          if (typeof value === "function") {
+            this._extras[i] = jsFunctionToMistQLFunction(value);
+          } else {
+            this._extras[i] = value.definition;
+          }
+        }
+      }
+    }
   }
 
   query = (query: string, data: any) => {
-    return execute(parseOrThrow(query), data, this.extras);
+    return execute(parseOrThrow(query), data, this._extras);
   };
 }
 

--- a/js/src/instance.ts
+++ b/js/src/instance.ts
@@ -1,0 +1,21 @@
+import { execute } from "./executor";
+import { parseOrThrow } from "./parser";
+import { FunctionClosure } from "./types";
+
+export type MistQLOptions = {
+  extras?: FunctionClosure;
+};
+
+export class MistQLInstance {
+  extras?: FunctionClosure;
+
+  constructor(options: MistQLOptions = {}) {
+    this.extras = options.extras;
+  }
+
+  query = (query: string, data: any) => {
+    return execute(parseOrThrow(query), data, this.extras);
+  };
+}
+
+export const defaultInstance = new MistQLInstance();

--- a/js/src/types.ts
+++ b/js/src/types.ts
@@ -68,7 +68,7 @@ export type ASTExpression =
 export type RuntimeValue =
   | RuntimeValue[]
   | { [key: string]: RuntimeValue }
-  | ExecutionFunction
+  | FunctionValue
   | RegExp
   | number
   | boolean
@@ -89,17 +89,25 @@ export type RuntimeValueType =
 export type Closure = {
   [varname: string]: RuntimeValue;
 };
+
 export type Stack = Closure[];
+
+export type FunctionClosure = {
+  [varname: string]: FunctionValue;
+};
 
 export type ExecutionFunction = (
   exp: ASTExpression,
   stack: Stack
 ) => RuntimeValue;
-export type BuiltinFunction = (
+
+export type FunctionValue = (
   args: ASTExpression[],
   stack: Stack,
   executeInner: ExecutionFunction
 ) => RuntimeValue;
+
+export type BuiltinFunction = FunctionValue;
 
 export type LexToken =
   | {

--- a/js/src/util.ts
+++ b/js/src/util.ts
@@ -1,6 +1,11 @@
 import { RuntimeError } from "./errors";
 import { getType } from "./runtimeValues";
-import { BuiltinFunction, RuntimeValue, RuntimeValueType } from "./types";
+import {
+  BuiltinFunction,
+  FunctionValue,
+  RuntimeValue,
+  RuntimeValueType,
+} from "./types";
 
 export function escapeRegExp(string: string): string {
   return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"); // $& means the whole matched string
@@ -27,18 +32,18 @@ export const seqHelper = (arr: boolean[][], start = 0): number[][] => {
 // Builtin Helpers
 export const arity =
   (arityCount: number | number[], fn: BuiltinFunction): BuiltinFunction =>
-    (args, stack, exec) => {
-      const validArity =
-        typeof arityCount === "number"
-          ? arityCount === args.length
-          : arityCount.indexOf(args.length) !== -1;
-      if (!validArity) {
-        throw new RuntimeError(
-          "Expected " + arityCount + " arguments, got " + args.length
-        );
-      }
-      return fn(args, stack, exec);
-    };
+  (args, stack, exec) => {
+    const validArity =
+      typeof arityCount === "number"
+        ? arityCount === args.length
+        : arityCount.indexOf(args.length) !== -1;
+    if (!validArity) {
+      throw new RuntimeError(
+        "Expected " + arityCount + " arguments, got " + args.length
+      );
+    }
+    return fn(args, stack, exec);
+  };
 
 export const validateType = (
   type: RuntimeValueType,
@@ -48,4 +53,12 @@ export const validateType = (
     throw new RuntimeError("Expected type " + type + ", got " + getType(value));
   }
   return value;
+};
+
+export const jsFunctionToMistQLFunction = (
+  fn: (...args: any[]) => any
+): FunctionValue => {
+  return arity(fn.length, (args, stack, exec) => {
+    return fn(...args.map((arg) => exec(arg, stack)));
+  });
 };

--- a/py/mistql/__init__.py
+++ b/py/mistql/__init__.py
@@ -1,3 +1,5 @@
 __version__ = "0.4.11"
 
 from .query import query  # noqa: F401
+from .instance import MistQLInstance  # noqa: F401
+from .runtime_value import RuntimeValue  # noqa: F401

--- a/py/mistql/execute.py
+++ b/py/mistql/execute.py
@@ -11,7 +11,7 @@ from mistql.expression import (
 )
 from mistql.stack import Stack
 from mistql.builtins import FunctionDefinitionType, builtins
-from mistql.stack import add_runtime_value_to_stack, build_initial_stack, find_in_stack
+from mistql.stack import add_runtime_value_to_stack, build_initial_stack, find_in_stack, StackFrame
 from mistql.expression import BaseExpression
 from mistql.exceptions import MistQLTypeError, OpenAnIssueIfYouGetThisError
 
@@ -69,5 +69,5 @@ def execute(ast: BaseExpression, stack: Stack) -> RuntimeValue:
     raise NotImplementedError("execute() not implemented for " + str(ast.type))
 
 
-def execute_outer(ast: Expression, data: RuntimeValue) -> RuntimeValue:
-    return execute(ast, build_initial_stack(data, builtins))
+def execute_outer(ast: Expression, data: RuntimeValue, extras: StackFrame) -> RuntimeValue:
+    return execute(ast, build_initial_stack(data, builtins, extras))

--- a/py/mistql/execute.py
+++ b/py/mistql/execute.py
@@ -11,7 +11,12 @@ from mistql.expression import (
 )
 from mistql.stack import Stack
 from mistql.builtins import FunctionDefinitionType, builtins
-from mistql.stack import add_runtime_value_to_stack, build_initial_stack, find_in_stack, StackFrame
+from mistql.stack import (
+    add_runtime_value_to_stack,
+    build_initial_stack,
+    find_in_stack,
+    StackFrame
+)
 from mistql.expression import BaseExpression
 from mistql.exceptions import MistQLTypeError, OpenAnIssueIfYouGetThisError
 
@@ -69,5 +74,9 @@ def execute(ast: BaseExpression, stack: Stack) -> RuntimeValue:
     raise NotImplementedError("execute() not implemented for " + str(ast.type))
 
 
-def execute_outer(ast: Expression, data: RuntimeValue, extras: StackFrame) -> RuntimeValue:
+def execute_outer(
+    ast: Expression,
+    data: RuntimeValue,
+    extras: StackFrame
+) -> RuntimeValue:
     return execute(ast, build_initial_stack(data, builtins, extras))

--- a/py/mistql/instance.py
+++ b/py/mistql/instance.py
@@ -1,0 +1,20 @@
+from typing import Any, Dict, Union, Callable
+
+from .execute import execute_outer
+from .runtime_value import RuntimeValue
+from .gardenwall import input_garden_wall, output_garden_wall
+from .parse import parse
+
+
+class MistQLInstance:
+    def __init__(self, extras: Dict[str, Union[RuntimeValue, Callable]]=None):
+        self.extras = extras or {}
+    
+    def query(self, query, data):
+        ast = parse(query)
+        data = input_garden_wall(data)
+        result = execute_outer(ast, data, self.extras)
+        return_value = output_garden_wall(result)
+        return return_value
+
+default_instance = MistQLInstance()

--- a/py/mistql/instance.py
+++ b/py/mistql/instance.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Union, Callable
+from typing import Dict, Union, Callable
 
 from .execute import execute_outer
 from .runtime_value import RuntimeValue
@@ -7,14 +7,15 @@ from .parse import parse
 
 
 class MistQLInstance:
-    def __init__(self, extras: Dict[str, Union[RuntimeValue, Callable]]=None):
+    def __init__(self, extras: Dict[str, Union[RuntimeValue, Callable]] = None):
         self.extras = extras or {}
-    
+
     def query(self, query, data):
         ast = parse(query)
         data = input_garden_wall(data)
         result = execute_outer(ast, data, self.extras)
         return_value = output_garden_wall(result)
         return return_value
+
 
 default_instance = MistQLInstance()

--- a/py/mistql/query.py
+++ b/py/mistql/query.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from .instance import default_instance
 
+
 def query(query: str, data: Any) -> Any:
     """
     Executes a query on a given data.

--- a/py/mistql/query.py
+++ b/py/mistql/query.py
@@ -1,11 +1,8 @@
 from typing import Any
 
-from .execute import execute_outer
-from .gardenwall import input_garden_wall, output_garden_wall
-from .parse import parse
+from .instance import default_instance
 
-
-def query(query: str, raw_data: Any) -> Any:
+def query(query: str, data: Any) -> Any:
     """
     Executes a query on a given data.
 
@@ -13,8 +10,4 @@ def query(query: str, raw_data: Any) -> Any:
     :param data: The data to query.
     :return: The result of the query.
     """
-    ast = parse(query)
-    data = input_garden_wall(raw_data)
-    result = execute_outer(ast, data)
-    return_value = output_garden_wall(result)
-    return return_value
+    return default_instance.query(query, data)

--- a/py/mistql/runtime_value.py
+++ b/py/mistql/runtime_value.py
@@ -104,7 +104,7 @@ class RuntimeValue:
         """
         Create a new function from a Python function that can be used in MistQL
         """
-        spec = inspect.getfullargspec(py_func) 
+        spec = inspect.getfullargspec(py_func)
         min_arity = len(spec.args)
         if spec.defaults is not None:
             min_arity -= len(spec.defaults)
@@ -121,16 +121,14 @@ class RuntimeValue:
 
         def definition(args, stack, exec):
             if len(args) < min_arity:
+                fstr = "Function takes no fewer than {} arguments but {} were provided"
                 raise MistQLTypeError(
-                    "Function takes no fewer than {} arguments but {} were provided".format(
-                        min_arity, len(args)
-                    )
+                    fstr.format(min_arity, len(args))
                 )
             if max_arity is not None and len(args) > max_arity:
+                fstr = "Function takes no more than {} arguments but {} were provided"
                 raise MistQLTypeError(
-                    "Function takes no more than {} arguments but {} were provided".format(
-                        max_arity, len(args)
-                    )
+                   fstr.format(max_arity, len(args))
                 )
             py_args = [exec(arg, stack).to_python() for arg in args]
             return RuntimeValue.of(py_func(*py_args))

--- a/py/mistql/runtime_value.py
+++ b/py/mistql/runtime_value.py
@@ -3,7 +3,7 @@ import re
 from datetime import date, datetime, time
 from enum import Enum
 from math import isfinite, isnan
-from typing import Any, Callable, Dict, Set, Union
+from typing import Any, Callable, Dict, Set, Union, Optional
 import inspect
 
 from mistql.exceptions import MistQLTypeError, OpenAnIssueIfYouGetThisError
@@ -109,7 +109,7 @@ class RuntimeValue:
         if spec.defaults is not None:
             min_arity -= len(spec.defaults)
 
-        max_arity = len(spec.args)
+        max_arity: Optional[int] = len(spec.args)
         if spec.varargs is not None:
             max_arity = None
 

--- a/py/mistql/stack.py
+++ b/py/mistql/stack.py
@@ -1,5 +1,5 @@
 from typing import List, Dict, Callable, Union
-from mistql.runtime_value import RuntimeValue, RuntimeValueType
+from mistql.runtime_value import RuntimeValue
 from mistql.exceptions import MistQLReferenceError
 from typeguard import typechecked
 
@@ -21,7 +21,11 @@ def add_runtime_value_to_stack(value: RuntimeValue, stack: Stack):
     return new_stack
 
 
-def build_initial_stack(data: RuntimeValue, builtins: Dict[str, Callable], extras: Dict[str, Union[Callable, RuntimeValue]]) -> Stack:
+def build_initial_stack(
+    data: RuntimeValue,
+    builtins: Dict[str, Callable],
+    extras: Dict[str, Union[Callable, RuntimeValue]]
+) -> Stack:
     functions_frame: StackFrame = {}
     for key, value in builtins.items():
         functions_frame[key] = RuntimeValue.wrap_function_def(value)
@@ -31,13 +35,13 @@ def build_initial_stack(data: RuntimeValue, builtins: Dict[str, Callable], extra
         else:
             functions_frame[key] = RuntimeValue.from_py_func(value)
 
-    dollar_var_dict = { "@": data }
+    dollar_var_dict = {"@": data}
     dollar_var_dict.update(functions_frame)
 
     return [
         functions_frame,
-        { "$": RuntimeValue.of(dollar_var_dict) },
-         make_stack_entry_from_runtime_value(data)
+        {"$": RuntimeValue.of(dollar_var_dict)},
+        make_stack_entry_from_runtime_value(data)
     ]
 
 

--- a/py/mistql/stack.py
+++ b/py/mistql/stack.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Callable, Union
+from typing import List, Mapping, Callable, Union, Dict
 from mistql.runtime_value import RuntimeValue
 from mistql.exceptions import MistQLReferenceError
 from typeguard import typechecked
@@ -23,12 +23,12 @@ def add_runtime_value_to_stack(value: RuntimeValue, stack: Stack):
 
 def build_initial_stack(
     data: RuntimeValue,
-    builtins: Dict[str, Callable],
-    extras: Dict[str, Union[Callable, RuntimeValue]]
+    builtins: Mapping[str, Callable],
+    extras: Mapping[str, Union[Callable, RuntimeValue]]
 ) -> Stack:
     functions_frame: StackFrame = {}
-    for key, value in builtins.items():
-        functions_frame[key] = RuntimeValue.wrap_function_def(value)
+    for key, builtin in builtins.items():
+        functions_frame[key] = RuntimeValue.wrap_function_def(builtin)
     for key, value in extras.items():
         if isinstance(value, RuntimeValue):
             functions_frame[key] = value

--- a/py/tests/test_custom_functions.py
+++ b/py/tests/test_custom_functions.py
@@ -1,0 +1,64 @@
+import pytest
+from mistql import MistQLInstance, RuntimeValue
+
+
+def test_basic_custom_function():
+    def add_one(x):
+        return x + 1
+    mq = MistQLInstance({
+        "add_one": add_one
+    })
+    assert mq.query("add_one 1", None) == 2
+
+
+def test_variadic_custom_function():
+    def add(*args):
+        return sum(args)
+    mq = MistQLInstance({
+        "add": add
+    })
+    assert mq.query("add 1 2 3", None) == 6
+    assert mq.query("add 1 2 3 4", None) == 10
+
+
+
+def test_variadic_custom_function_with_positionals():
+    def add(x, *args):
+        return x + sum(args)
+    mq = MistQLInstance({
+        "add": add
+    })
+    assert mq.query("add 5", None) == 5
+    assert mq.query("add 5 2", None) == 7
+    assert mq.query("add 5 2 3", None) == 10
+
+
+def test_bad_arity_raises():
+    def add(x, y):
+        return x + y
+    mq = MistQLInstance({
+        "add": add
+    })
+    assert mq.query("add 1 2", None) == 3
+    with pytest.raises(Exception):
+        mq.query("add 1", None)
+
+
+def test_kw_only_args_throw():
+    def add(*, x):
+        return x
+    with pytest.raises(Exception):
+        # Should move to erroring on instance creation
+        mq = MistQLInstance({
+            "add": add
+        })
+        mq.query("add 1", None)
+
+
+def test_using_runtime_value_construction():
+    def add(args, stack, exec):
+        return RuntimeValue.of(exec(args[0], stack).value + exec(args[1], stack).value)
+    mq = MistQLInstance({
+        "add": RuntimeValue.wrap_function_def(add)
+    })
+    assert mq.query("add 1 2", None) == 3

--- a/py/tests/test_custom_functions.py
+++ b/py/tests/test_custom_functions.py
@@ -21,7 +21,6 @@ def test_variadic_custom_function():
     assert mq.query("add 1 2 3 4", None) == 10
 
 
-
 def test_variadic_custom_function_with_positionals():
     def add(x, *args):
         return x + sum(args)


### PR DESCRIPTION
Adds interface and light documentation for supplying custom functions to Python and JavaScript implementations. This is mostly functionally complete after this pull. In order to supply a custom environment for working with MistQL, part of this pull is introducing the (hopefully rarely used) idea of a MistQL Instance, e.g. a configurable environment in which a MistQL expression is parsed.

This is still in progress, and while I don't expect this interface to change over time, we shouldn't consider this quite as stable as the rest of the platform, and should mark that in the documentation.