### PR TITLE
Fix typo in withindices documentation

### DIFF
--- a/docs/docs/reference/functions.md
+++ b/docs/docs/reference/functions.md
@@ -794,7 +794,7 @@ Maps an array to a list of tuple-like arrays with the index as the first member 
 Query:
 
 ```
-["a", "b", "c", "d"] | values
+["a", "b", "c", "d"] | withindices
 ```
 
 Result:


### PR DESCRIPTION
Hi,

There's a typo in the `withindices` documentation: the example uses `values` instead of `withindices`.

Here's a fix.