### PR TITLE
Make typeguard opt-in, opt the automated tests into typeguard

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -12,6 +12,8 @@ jobs:
     defaults:
       run:
         working-directory: ./py
+    env:
+      TYPEGUARD_ENABLED: 1
 
     strategy:
       fail-fast: false

--- a/py/mistql/execute.py
+++ b/py/mistql/execute.py
@@ -19,7 +19,7 @@ from mistql.stack import (
 from mistql.expression import BaseExpression
 from mistql.exceptions import MistQLTypeError, OpenAnIssueIfYouGetThisError
 
-from typeguard import typechecked
+from mistql.typeguard_wrapper import typechecked
 
 
 @typechecked

--- a/py/mistql/expression.py
+++ b/py/mistql/expression.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import Dict, List, Union, Any
 from mistql.runtime_value import RuntimeValue
 
-from typeguard import typechecked
+from mistql.typeguard_wrapper import typechecked
 
 
 class ExpressionType(Enum):

--- a/py/mistql/stack.py
+++ b/py/mistql/stack.py
@@ -1,7 +1,7 @@
 from typing import List, Mapping, Callable, Union, Dict
 from mistql.runtime_value import RuntimeValue
 from mistql.exceptions import MistQLReferenceError
-from typeguard import typechecked
+from mistql.typeguard_wrapper import typechecked
 
 StackFrame = Dict[str, RuntimeValue]
 Stack = List[StackFrame]

--- a/py/mistql/typeguard_wrapper.py
+++ b/py/mistql/typeguard_wrapper.py
@@ -1,0 +1,10 @@
+from typeguard import typechecked as typechecked_decorator
+from os import environ
+
+typeguard_enabled = environ.get("TYPEGUARD_ENABLED", "").lower() in ("1", "true", "yes")
+
+
+def typechecked(func):
+    if typeguard_enabled:
+        return typechecked_decorator(func)
+    return func


### PR DESCRIPTION
Typeguard errors are exceptionally rare, and cost us a lot in production. This change disables them unless a specific env is set. Additionally, we set it in the workflow to ensure everything's operating as expected.

Depending on query, this is a ~1.4x perf boost by some very simple measurements, but I expect this number to be highly variable. ymmv