### PR TITLE
Fix JS tests

### DIFF
--- a/js/src/builtins/filterkeys.ts
+++ b/js/src/builtins/filterkeys.ts
@@ -1,11 +1,10 @@
 import { truthy } from "../runtimeValues";
 import { pushRuntimeValueToStack } from "../stackManip";
 import { BuiltinFunction } from "../types";
-import { arity } from "../util";
-
+import { arity, validateType } from "../util";
 
 const filterkeys: BuiltinFunction = arity(2, (args, stack, exec) => {
-  const evaluated = exec(args[1], stack);
+  const evaluated = validateType("object", exec(args[1], stack));
   const results = {};
   for (let i in evaluated) {
     if (

--- a/js/src/builtins/filtervalues.ts
+++ b/js/src/builtins/filtervalues.ts
@@ -1,11 +1,10 @@
 import { truthy } from "../runtimeValues";
 import { pushRuntimeValueToStack } from "../stackManip";
 import { BuiltinFunction } from "../types";
-import { arity } from "../util";
-
+import { arity, validateType } from "../util";
 
 const filtervalues: BuiltinFunction = arity(2, (args, stack, exec) => {
-  const evaluated = exec(args[1], stack);
+  const evaluated = validateType("object", exec(args[1], stack));
   const results = {};
   for (let i in evaluated) {
     if (

--- a/js/src/builtins/index.ts
+++ b/js/src/builtins/index.ts
@@ -96,6 +96,13 @@ const divide = numericBinaryOperator((a, b) => {
   return a / b;
 });
 
+const modulo = numericBinaryOperator((a, b) => {
+  if (b === 0) {
+    throw new RuntimeError("Modulo by zero");
+  }
+  return a % b;
+});
+
 export default {
   apply,
   count,
@@ -139,7 +146,7 @@ export default {
   "-": numericBinaryOperator((a, b) => a - b),
   "*": numericBinaryOperator((a, b) => a * b),
   "/": divide,
-  "%": numericBinaryOperator((a, b) => a % b),
+  "%": modulo,
   "||": or,
   "&&": and,
   "==": equal,

--- a/js/src/builtins/mapkeys.ts
+++ b/js/src/builtins/mapkeys.ts
@@ -1,13 +1,15 @@
 import { pushRuntimeValueToStack } from "../stackManip";
 import { BuiltinFunction } from "../types";
-import { arity } from "../util";
+import { arity, validateType } from "../util";
 import { castToString, getProperties } from "../runtimeValues";
 
 const mapkeys: BuiltinFunction = arity(2, (args, stack, exec) => {
-  const evaluated = exec(args[1], stack);
+  const evaluated = validateType("object", exec(args[1], stack));
   const results = {};
   getProperties(evaluated).forEach((key) => {
-    const newKey = castToString(exec(args[0], pushRuntimeValueToStack(key, stack)))
+    const newKey = castToString(
+      exec(args[0], pushRuntimeValueToStack(key, stack))
+    );
     results[newKey] = evaluated[key];
   });
   return results;

--- a/js/src/builtins/mapvalues.ts
+++ b/js/src/builtins/mapvalues.ts
@@ -1,10 +1,10 @@
 import { pushRuntimeValueToStack } from "../stackManip";
 import { BuiltinFunction } from "../types";
-import { arity } from "../util";
+import { arity, validateType } from "../util";
 import { getProperties } from "../runtimeValues";
 
 const mapvalues: BuiltinFunction = arity(2, (args, stack, exec) => {
-  const evaluated = exec(args[1], stack);
+  const evaluated = validateType("object", exec(args[1], stack));
   const results = {};
   getProperties(evaluated).forEach((key) => {
     results[key] = exec(

--- a/js/src/runtimeValues.ts
+++ b/js/src/runtimeValues.ts
@@ -30,7 +30,13 @@ export const castToString = (value: RuntimeValue): RuntimeValue => {
   } else if (type === "regex" || typeof value === "function") {
     throw new Error("Cannot cast type " + type + " to string");
   } else {
-    return JSON.stringify(value);
+    return JSON.stringify(value, (_, value) => {
+      const type = getType(value);
+      if (type === "regex" || typeof value === "function") {
+        throw new Error("Cannot cast type " + type + " to string");
+      }
+      return value;
+    });
   }
 };
 


### PR DESCRIPTION
This has behavioral changes to:

Restricting to operating on objects:
* `filterkeys`
* `filtervalues`
* `matchkeys`
* `matchvalues`

Bugs:
* `modulo` by zero now throws (could be considered a bug)
* `string` now fails on deeply nested non-stringable types.
